### PR TITLE
feat(k8s): add Kubernetes manifests package for local k3d deployment

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,68 @@
+# Kubernetes manifests (k3d + local registry)
+
+Este pacote sobe os servicos `discovery`, `log`, `gateway` e um `postgres` no namespace `microservices`.
+
+## Estrutura
+
+- `k8s/base`: manifests base para todos os ambientes
+- `k8s/overlays/local-k3d`: overlay para uso local com k3d e registry local
+
+## 1) Criar cluster k3d com registry local
+
+Se voce ainda nao tem um cluster configurado com registry, este fluxo cria tudo do zero:
+
+```bash
+k3d registry create local-reg --port 5000
+k3d cluster create microservices --servers 1 --agents 1 --registry-use k3d-local-reg:5000 -p "8080:80@loadbalancer"
+```
+
+Se voce ja possui cluster, confirme se ele enxerga o registry que voce usa para `localhost:5000`.
+
+## 2) Build e push das imagens
+
+No root do monorepo:
+
+```bash
+./mvnw -pl discovery -am spring-boot:build-image -Dspring-boot.build-image.imageName=localhost:5000/micro/discovery:1.0.0
+./mvnw -pl log -am spring-boot:build-image -Dspring-boot.build-image.imageName=localhost:5000/micro/log:1.0.0
+./mvnw -pl gateway -am spring-boot:build-image -Dspring-boot.build-image.imageName=localhost:5000/micro/gateway:1.0.0
+
+docker push localhost:5000/micro/discovery:1.0.0
+docker push localhost:5000/micro/log:1.0.0
+docker push localhost:5000/micro/gateway:1.0.0
+```
+
+Se quiser mudar a tag, atualize `k8s/overlays/local-k3d/kustomization.yaml`.
+
+## 3) Aplicar os manifests
+
+```bash
+kubectl apply -k k8s/overlays/local-k3d
+```
+
+## 4) Validar rollout
+
+```bash
+kubectl get all -n microservices
+kubectl get ingress -n microservices
+kubectl logs -n microservices deploy/discovery
+kubectl logs -n microservices deploy/log
+kubectl logs -n microservices deploy/gateway
+```
+
+## 5) Acesso
+
+Com Traefik (default do k3s/k3d), o gateway fica em:
+
+- `http://gateway.localtest.me/`
+- Exemplo de rota: `http://gateway.localtest.me/gateway/log/course`
+
+## Variaveis importantes
+
+As principais configuracoes estao em:
+
+- `k8s/base/configmap-app.yaml`
+- `k8s/base/secret-app.yaml`
+
+Ajuste esses arquivos para seu ambiente (principalmente credenciais e URL do banco).
+

--- a/k8s/base/configmap-app.yaml
+++ b/k8s/base/configmap-app.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: microservices
+data:
+  EUREKA_DEFAULT_ZONE: "http://discovery:8081/eureka"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/devdojo"
+

--- a/k8s/base/discovery-deployment.yaml
+++ b/k8s/base/discovery-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: discovery
+  namespace: microservices
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: discovery
+  template:
+    metadata:
+      labels:
+        app: discovery
+    spec:
+      containers:
+        - name: discovery
+          image: localhost:5000/micro/discovery:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8081
+          env:
+            - name: SERVER_PORT
+              value: "8081"
+            - name: SPRING_APPLICATION_NAME
+              value: registry
+            - name: EUREKA_INSTANCE_HOSTNAME
+              value: discovery
+            - name: EUREKA_CLIENT_REGISTER_WITH_EUREKA
+              value: "false"
+            - name: EUREKA_CLIENT_FETCH_REGISTRY
+              value: "false"
+            - name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
+              value: http://discovery:8081/eureka/
+          readinessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 30
+            periodSeconds: 10
+

--- a/k8s/base/discovery-service.yaml
+++ b/k8s/base/discovery-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: discovery
+  namespace: microservices
+spec:
+  selector:
+    app: discovery
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081
+

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: microservices
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: localhost:5000/micro/gateway:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SERVER_PORT
+              value: "8080"
+            - name: SPRING_APPLICATION_NAME
+              value: gateway
+            - name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: EUREKA_DEFAULT_ZONE
+            - name: EUREKA_INSTANCE_PREFER_IP_ADDRESS
+              value: "true"
+            - name: EUREKA_CLIENT_FETCH_REGISTRY
+              value: "true"
+            - name: EUREKA_CLIENT_REGISTER_WITH_EUREKA
+              value: "true"
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 40
+            periodSeconds: 10
+

--- a/k8s/base/gateway-ingress.yaml
+++ b/k8s/base/gateway-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway
+  namespace: microservices
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - host: gateway.localtest.me
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  number: 8080
+

--- a/k8s/base/gateway-service.yaml
+++ b/k8s/base/gateway-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: microservices
+spec:
+  selector:
+    app: gateway
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap-app.yaml
+  - secret-app.yaml
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-service.yaml
+  - discovery-deployment.yaml
+  - discovery-service.yaml
+  - log-deployment.yaml
+  - log-service.yaml
+  - gateway-deployment.yaml
+  - gateway-service.yaml
+  - gateway-ingress.yaml
+

--- a/k8s/base/log-deployment.yaml
+++ b/k8s/base/log-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: log
+  namespace: microservices
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: log
+  template:
+    metadata:
+      labels:
+        app: log
+    spec:
+      containers:
+        - name: log
+          image: localhost:5000/micro/log:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8082
+          env:
+            - name: SERVER_PORT
+              value: "8082"
+            - name: SPRING_APPLICATION_NAME
+              value: log
+            - name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: EUREKA_DEFAULT_ZONE
+            - name: SPRING_DATASOURCE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: SPRING_DATASOURCE_URL
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SPRING_DATASOURCE_USERNAME
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SPRING_DATASOURCE_PASSWORD
+            - name: EUREKA_INSTANCE_PREFER_IP_ADDRESS
+              value: "true"
+            - name: EUREKA_CLIENT_FETCH_REGISTRY
+              value: "true"
+            - name: EUREKA_CLIENT_REGISTER_WITH_EUREKA
+              value: "true"
+          readinessProbe:
+            tcpSocket:
+              port: 8082
+            initialDelaySeconds: 20
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 8082
+            initialDelaySeconds: 45
+            periodSeconds: 10
+

--- a/k8s/base/log-service.yaml
+++ b/k8s/base/log-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: log
+  namespace: microservices
+spec:
+  selector:
+    app: log
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: microservices
+

--- a/k8s/base/postgres-deployment.yaml
+++ b/k8s/base/postgres-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: microservices
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:12
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: POSTGRES_DB
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data
+

--- a/k8s/base/postgres-pvc.yaml
+++ b/k8s/base/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: microservices
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/k8s/base/postgres-service.yaml
+++ b/k8s/base/postgres-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: microservices
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: tcp
+      port: 5432
+      targetPort: 5432
+

--- a/k8s/base/secret-app.yaml
+++ b/k8s/base/secret-app.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+  namespace: microservices
+type: Opaque
+stringData:
+  SPRING_DATASOURCE_USERNAME: postgres
+  SPRING_DATASOURCE_PASSWORD: postgres
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres
+  POSTGRES_DB: devdojo
+

--- a/k8s/overlays/local-k3d/kustomization.yaml
+++ b/k8s/overlays/local-k3d/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+images:
+  - name: localhost:5000/micro/discovery
+    newName: localhost:5000/micro/discovery
+    newTag: "1.0.0"
+  - name: localhost:5000/micro/log
+    newName: localhost:5000/micro/log
+    newTag: "1.0.0"
+  - name: localhost:5000/micro/gateway
+    newName: localhost:5000/micro/gateway
+    newTag: "1.0.0"
+


### PR DESCRIPTION
## Title
feat(k8s): add Kubernetes manifests package for local k3d deployment

## Context
Esta PR adiciona um pacote de manifests Kubernetes para subir o monorepo localmente com `k3d` + registry local, sem alterar código das aplicações.

Objetivo:
- padronizar o deploy local dos serviços `discovery`, `log`, `gateway` e `postgres`;
- facilitar validação de integração entre serviços via Eureka;
- centralizar documentação de uso em `k8s/README.md`.

## What changed

### Kubernetes structure
- Criação da base em `k8s/base` com:
  - `namespace.yaml`
  - `configmap-app.yaml`
  - `secret-app.yaml`
  - `postgres-pvc.yaml`
  - `postgres-deployment.yaml`
  - `postgres-service.yaml`
  - `discovery-deployment.yaml`
  - `discovery-service.yaml`
  - `log-deployment.yaml`
  - `log-service.yaml`
  - `gateway-deployment.yaml`
  - `gateway-service.yaml`
  - `gateway-ingress.yaml`
  - `kustomization.yaml`

### Overlay local
- Criação de `k8s/overlays/local-k3d/kustomization.yaml` para uso local com `k3d` e imagens no registry local.

### Documentation
- Adição de `k8s/README.md` com:
  - criação de cluster/registry local;
  - build + push de imagens;
  - deploy com `kubectl apply -k`;
  - comandos de validação;
  - variáveis e arquivos de configuração relevantes.

## Technical decisions
- Uso de `Kustomize` para separar base e ambiente local.
- Configuração de app settings em `ConfigMap` (`k8s/base/configmap-app.yaml`).
- Credenciais e dados sensíveis em `Secret` (`k8s/base/secret-app.yaml`).
- Postgres com `PVC` para persistência local.
- Probes TCP básicas para `postgres`, `discovery`, `log` e `gateway`.
- Ingress para gateway com host `gateway.localtest.me` (Traefik no k3d/k3s).

## Validation
- Renderização de manifests validada com:
  - `kubectl kustomize k8s/overlays/local-k3d`

> Observação: esta PR adiciona infraestrutura/manifests. A execução completa depende de imagens publicadas no registry local (`localhost:5000`) e cluster `k3d` configurado para consumi-las.

## How to test locally
```bash
kubectl apply -k k8s/overlays/local-k3d
kubectl get all -n microservices
kubectl get ingress -n microservices
kubectl logs -n microservices deploy/discovery
kubectl logs -n microservices deploy/log
kubectl logs -n microservices deploy/gateway
